### PR TITLE
New features and restructuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A plugin for [Vencord, a Discord client mod](https://vencord.dev) that automatic
 
 [Original plugin by Maddie480](https://github.com/maddie480/Vencord-AutoThemeSwitcher) and includes [system appearance code from adorabilis' fork.](https://github.com/adorabilis/Vencord-SystemThemeSwitcher/)
 
-<div><img width="500" height="auto" alt="plugin time" src="https://github.com/user-attachments/assets/531c8b4d-01d3-4894-9d80-005715d12eed" /><img width="500" height="auto" alt="plugin system" src="https://github.com/user-attachments/assets/2245f365-c127-4f25-a160-01faa0a2ac6f" /> </div>
+<div><img style="width: 50%" height="auto" alt="plugin time" src="https://github.com/user-attachments/assets/531c8b4d-01d3-4894-9d80-005715d12eed" /><img style="width: 50%" height="auto" alt="plugin system" src="https://github.com/user-attachments/assets/2245f365-c127-4f25-a160-01faa0a2ac6f" /> </div>
 
 ## Installing the plugin
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A plugin for [Vencord, a Discord client mod](https://vencord.dev) that automatic
 
 [Original plugin by Maddie480](https://github.com/maddie480/Vencord-AutoThemeSwitcher) and includes [system appearance code from adorabilis' fork.](https://github.com/adorabilis/Vencord-SystemThemeSwitcher/)
 
-![Screenshot of plugin settings](https://maddie480.ovh/static/img/auto-theme-switcher.png)
+<div><img width="500" height="auto" alt="plugin time" src="https://github.com/user-attachments/assets/531c8b4d-01d3-4894-9d80-005715d12eed" /><img width="500" height="auto" alt="plugin system" src="https://github.com/user-attachments/assets/2245f365-c127-4f25-a160-01faa0a2ac6f" /> </div>
 
 ## Installing the plugin
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # AutoThemeSwitcher
 
-A plugin for [Vencord, a Discord client mod](https://vencord.dev) that automatically switches between 2 themes based on the time of day. Useful for people that would like to set up a "light theme at day, dark theme at night" schedule.
+A plugin for [Vencord, a Discord client mod](https://vencord.dev) that automatically switches between 2 themes. The toggle is based on the time of day, or system appearance, depending on a toggle setting. Useful for people that would like to set up a "light theme at day, dark theme at night" schedule.
+
+[Original plugin by Maddie480](https://github.com/maddie480/Vencord-AutoThemeSwitcher) and includes [system appearance code from adorabilis' fork.](https://github.com/adorabilis/Vencord-SystemThemeSwitcher/)
 
 ![Screenshot of plugin settings](https://maddie480.ovh/static/img/auto-theme-switcher.png)
 
@@ -18,6 +20,6 @@ This means the light theme will be applied from 08:00 to 20:00, and the dark the
 
 ## Theme Configurations
 
-The dropdown allows you to pick the base "Light" and "Dark" themes, and all of the Nitro themes. **Using Nitro themes requires Nitro, or activating the FakeNitro plugin.**
+The dropdown allows you to pick the base "Light" and "Dark" themes, and all of the Nitro themes, including the custom Nitro theme. **Using Nitro themes requires Nitro, or activating the FakeNitro plugin.**
 
-Additionally, you can specify CSS theme URLs. If you fill those fields, this will **replace** your "Online Themes" settings when the theme is toggled. The choice of Light or Dark theme will still have an effect.
+Additionally, you can specify CSS theme URLs, if they are under the HTTP protocol. If you fill those fields, this will **replace** your "Online Themes" settings when the theme is toggled. The choice of Light or Dark theme will still have an effect.

--- a/index.tsx
+++ b/index.tsx
@@ -9,26 +9,75 @@ import definePlugin, { StartAt } from "@utils/types";
 import * as pluginSettings from "./pluginSettings";
 import * as themeScheduler from "./themeScheduler";
 import * as themeToggler from "./themeToggler";
-import { ToggledTheme } from "./types";
+import { CtStore, CustomTheme, ToggledTheme } from "./types";
+import { findStore } from "@webpack";
 
-const settings = pluginSettings.getPluginSettings(onChange);
+// Import settings immediately
+let settings = pluginSettings.getPluginSettings(onChange);
 
 let currentTheme: ToggledTheme | null = null;
 let intervalHandle: NodeJS.Timeout | null = null;
+let mediaQueryList: MediaQueryList | null = null;
 let pluginStarted: boolean = false;
 
+/**
+ * Function that updates the current theme if the plugin has started
+ */
 function onChange() {
     if (pluginStarted) {
         updateTheme();
     }
 }
 
-function updateTheme() {
-    const expectedTheme = themeScheduler.getExpectedTheme(settings.store.lightThemeStartTime, settings.store.darkThemeStartTime);
-    const discordTheme = expectedTheme === ToggledTheme.Dark ? settings.store.darkTheme : settings.store.lightTheme;
+/**
+ * Main function; updates the theme depending on either time of day or system appearance
+ * @param isDark The output of the media query, which is the current system theme; true if dark, false if not
+ */
+function updateTheme(isDark?: boolean) {
+    // If isDark is not provided, check the media query
+    if (isDark === undefined && mediaQueryList) {
+        isDark = mediaQueryList.matches;
+    } else if (isDark === undefined) {
+        // Fallback if media query is not available
+        isDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    }
+
+    // Decide which method to find the expected theme based on the toggle setting
+    let expectedTheme: ToggledTheme;
+    if (settings.store.ChangeBasedOnSystemAppearance) {
+        // System appearance
+        expectedTheme = isDark ? ToggledTheme.Dark : ToggledTheme.Light;
+    }
+    else {
+        // Time of day
+        expectedTheme = themeScheduler.getExpectedTheme(settings.store.lightThemeStartTime, settings.store.darkThemeStartTime);
+    }
+
+    let discordTheme: string | CustomTheme = expectedTheme === ToggledTheme.Dark ? settings.store.darkTheme : settings.store.lightTheme;
+
+    //Set the theme property if this is the custom Nitro theme
+    if (discordTheme == "customnitro") {
+        //Get custom theme information from the store
+        let customThemeStore: CtStore = findStore("SavedCustomThemeStore") as CtStore;
+        let themeInfo: CustomTheme = { theme: "dark", customUserThemeSettings: customThemeStore.getSavedCustomTheme() };
+
+        // Set if the custom theme should be light or dark and return it
+        if (expectedTheme === ToggledTheme.Dark) {
+            themeInfo.theme = "dark";
+            discordTheme = themeInfo;
+        }
+        else {
+            themeInfo.theme = "light";
+            discordTheme = themeInfo;
+        }
+
+    }
+
+    // Get custom theme URLs
     const customCssURLs = expectedTheme === ToggledTheme.Dark ? settings.store.darkThemeURLs : settings.store.lightThemeURLs;
 
-    themeToggler.changeDiscordTheme(discordTheme as string);
+    themeToggler.changeDiscordTheme(discordTheme);
+
     if (customCssURLs) {
         themeToggler.changeCustomCssUrls(customCssURLs);
     }
@@ -36,6 +85,10 @@ function updateTheme() {
     currentTheme = expectedTheme;
 }
 
+/**
+ * Function that periodically updates the system theme (when changing is set by time of day)
+ * If the current theme is not expected, ie not what the settings are, update it
+ */
 function periodicThemeUpdateCheck() {
     const expectedTheme = themeScheduler.getExpectedTheme(settings.store.lightThemeStartTime, settings.store.darkThemeStartTime);
     if (expectedTheme !== currentTheme) {
@@ -43,21 +96,45 @@ function periodicThemeUpdateCheck() {
     }
 }
 
+/**
+ * Function that updates the current theme if there is a system appearance change
+ * @param event The MediaQueryListEvent that detects if the system is in dark mode or not
+ */
+function handleSystemThemeChange(event: MediaQueryListEvent) {
+    updateTheme(event.matches);
+}
+
 export default definePlugin({
     name: "AutoThemeSwitcher",
-    description: "Automatically switches between themes based on the time of day",
+    description: "Automatically switches between themes based on the time of day, or based on system appearance (ie. light/dark mode). Now supports custom themes!",
     authors: [{
         name: "maddie480",
         id: 354341658352943115n
+    },
+    {
+        name: "adorabilis",
+        id: 157156034136244224n
+    },
+    {
+        name: "ichi0995",
+        id: 176761898581229569n
     }],
     settings,
     startAt: StartAt.WebpackReady,
     start() {
+        //Start system listeners and periodic checks along with changing the theme
+        mediaQueryList = window.matchMedia("(prefers-color-scheme: dark)");
+        mediaQueryList.addEventListener("change", handleSystemThemeChange);
         updateTheme();
-        intervalHandle = setInterval(periodicThemeUpdateCheck, 60000);
+        intervalHandle = setInterval(periodicThemeUpdateCheck, 1000);
         pluginStarted = true;
     },
     stop() {
+        // Clear everything
+        if (mediaQueryList !== null) {
+            mediaQueryList.removeEventListener("change", handleSystemThemeChange);
+            mediaQueryList = null;
+        }
         if (intervalHandle !== null) {
             clearInterval(intervalHandle);
             intervalHandle = null;

--- a/index.tsx
+++ b/index.tsx
@@ -126,7 +126,7 @@ export default definePlugin({
         mediaQueryList = window.matchMedia("(prefers-color-scheme: dark)");
         mediaQueryList.addEventListener("change", handleSystemThemeChange);
         updateTheme();
-        intervalHandle = setInterval(periodicThemeUpdateCheck, 1000);
+        intervalHandle = setInterval(periodicThemeUpdateCheck, 60000);
         pluginStarted = true;
     },
     stop() {

--- a/pluginSettings.ts
+++ b/pluginSettings.ts
@@ -4,24 +4,33 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { definePluginSettings } from "@api/Settings";
+import { definePluginSettings, Settings } from "@api/Settings";
 import { proxyLazy } from "@utils/lazy";
 import { OptionType, SettingsDefinition } from "@utils/types";
 
 import { ThemeLinksComponent } from "./themeLinksComponent";
+import { timeComponent } from "./timeComponent";
 import * as themeLister from "./themeLister";
 import { ToggledTheme } from "./types";
 
+/**
+ * @param theme The ToggledTheme enum that represents changing to a light theme or dark theme
+ * @param onChange The onChange method from index.tsx
+ * @returns The settings that should be used depending on if the theme is light or dark
+ */
 function getToggledThemeSettings(theme: ToggledTheme, onChange: () => void): SettingsDefinition {
-    const themeName = theme === ToggledTheme.Light ? "Light Theme" : "Dark Theme";
     const defaultStartTime = theme === ToggledTheme.Light ? "08:00" : "20:00";
-
     return {
         themeStartTime: {
-            description: `In HH:MM format. For example: ${defaultStartTime}`,
-            type: OptionType.STRING,
-            default: defaultStartTime,
-            onChange
+            type: OptionType.COMPONENT,
+            onChange,
+            // TimeComponent is necessary, see TimeComponent.tsx
+            component: props => timeComponent(
+                props,
+                theme === ToggledTheme.Light ? "lightThemeStartTime" : "darkThemeStartTime",
+                defaultStartTime,
+                `In HH:MM format. For example: ${defaultStartTime}`,
+            )
         },
         theme: {
             description: "",
@@ -34,35 +43,35 @@ function getToggledThemeSettings(theme: ToggledTheme, onChange: () => void): Set
             onChange,
             component: props => ThemeLinksComponent(
                 props,
-                theme === ToggledTheme.Light ? "lightThemeURLs" : "darkThemeURLs",
-                `${themeName} CSS URLs (1 per line)`
+                theme === ToggledTheme.Light ? "lightThemeURLS" : "darkThemeURLS",
+                "One per line, HTTP or HTTPS only"
             ),
         },
     };
 }
 
-const timeRegex = /^([0-1][0-9]|2[0-3]):([0-5][0-9])$/;
-
-function regexValidateCheck() {
-    return {
-        isValid: (newValue: string) => newValue.match(timeRegex) !== null
-    };
-}
-
+/**
+ * @param @param onChange The onChange method from index.tsx
+ * @returns The DefinedSettings, ie the fully configured settings, of the plugin
+ */
 export function getPluginSettings(onChange: () => void) {
     const lightThemeSettings = getToggledThemeSettings(ToggledTheme.Light, onChange);
     const darkThemeSettings = getToggledThemeSettings(ToggledTheme.Dark, onChange);
 
-    const settings = definePluginSettings({
+    let settings = definePluginSettings({
+
+        ChangeBasedOnSystemAppearance: {
+            type: OptionType.BOOLEAN,
+            description: "Select this to switch between custom light and dark themes based on your system appearance settings rather than the time of day.",
+            default: false,
+            onChange
+        },
         lightThemeStartTime: lightThemeSettings.themeStartTime,
         lightTheme: lightThemeSettings.theme,
         lightThemeURLs: lightThemeSettings.themeURLs,
         darkThemeStartTime: darkThemeSettings.themeStartTime,
         darkTheme: darkThemeSettings.theme,
-        darkThemeURLs: darkThemeSettings.themeURLs,
-    }, {
-        lightThemeStartTime: regexValidateCheck(),
-        darkThemeStartTime: regexValidateCheck(),
+        darkThemeURLs: darkThemeSettings.themeURLs
     });
 
     return settings;

--- a/themeLinksComponent.tsx
+++ b/themeLinksComponent.tsx
@@ -5,27 +5,56 @@
  */
 
 import { Settings } from "@api/Settings";
+import { SettingsSection, resolveError } from "@components/settings/tabs/plugins/components/Common";
 import { IPluginOptionComponentProps } from "@utils/types";
-import { Forms, React, TextArea } from "@webpack/common";
+import { React, TextArea } from "@webpack/common";
 
+/**
+ * Creation of a JSX text component that becomes the theme links input box
+ * @param setValue Properties of the specific setting; only the setValue function is necessary, for changing the value if valid
+ * @param id The id of the setting the text box represents
+ * @param description A description of the input text box
+ * @returns Input text box JSX for theme links
+ */
 export function ThemeLinksComponent({ setValue }: IPluginOptionComponentProps, id: string, description: string) {
+    // Get the current state of the specific setting referenced by id, as well as the method to change it
     const [state, setState] = React.useState(Settings.plugins.AutoThemeSwitcher?.[id] ?? null);
+    const [error, setError] = React.useState<string | null>(null);
 
-    function handleChange(newValue) {
+    // Internal function to check if the URL(s) is/are valid
+    function regexValidateCheck(newValue: string) {
+        const URLRegex = /^(http[s]?:\/\/[^\s]+\.css)$/;
+        return newValue.match(URLRegex) !== null;
+    };
+
+
+    // Internal function to handle changes in the value
+    function handleChange(newValue: string) {
+        // Check validity on our own terms
+        // This behemoth of a line checks every newline if it is a URL, removes newline characters, then returns true if all newline URLs are valid, false otherwise
+        const isValid = (newValue.split(/(\r?\n)/)
+            .filter((line) => ["\n", ""].indexOf(line) < 0)
+            .map((line: string) => regexValidateCheck(line)))
+            .every(value => value);
+
         setState(newValue);
-        setValue(newValue);
+        setError(resolveError(isValid));
+
+        if (isValid === true) {
+            setValue(newValue);
+        }
     }
 
+    // Set up the text area to return
     return (
-        <Forms.FormSection>
-            <Forms.FormTitle>{description}</Forms.FormTitle>
+        <SettingsSection error={error} name={id} description={description}>
             <TextArea
                 value={state}
                 onChange={handleChange}
-                placeholder="Do not change"
+                placeholder=""
                 rows={5}
                 className={"vc-settings-theme-links"}
             />
-        </Forms.FormSection>
+        </SettingsSection>
     );
 }

--- a/themeLister.ts
+++ b/themeLister.ts
@@ -7,7 +7,6 @@
 import { getIntlMessage } from "@utils/discord";
 import { PluginSettingSelectOption } from "@utils/types";
 import { mapMangledModuleLazy } from "@webpack";
-
 import * as themeToggler from "./themeToggler";
 import { DiscordTheme, ToggledTheme } from "./types";
 
@@ -24,11 +23,24 @@ const nitroThemeList: { themes: Array<DiscordTheme>; } = mapMangledModuleLazy(",
  * @returns The options for a dropdown that contains Light, Dark and all Nitro themes
  */
 export function getSelectOptions(defaultValue: ToggledTheme): PluginSettingSelectOption[] {
-    const list = [...classicThemeList, ...nitroThemeList.themes].map(theme => ({
+    let list: ({
+        label: string;
+        value: string;
+        default: boolean
+    })[];
+
+    list = [...classicThemeList, ...nitroThemeList.themes,].map(theme => ({
         label: theme.getName(),
         value: themeToggler.themeToString(theme),
         default: false
     }));
+
+    // Unique value for the custom Nitro theme (it gets more defined in index.tsx)
+    list.push({
+        label: "Custom Nitro Theme",
+        value: "customnitro",
+        default: false
+    });
 
     const defaultIndex = defaultValue === ToggledTheme.Light ? 0 : 1;
     list[defaultIndex].default = true;

--- a/themeScheduler.ts
+++ b/themeScheduler.ts
@@ -6,6 +6,10 @@
 
 import { ToggledTheme } from "./types";
 
+/**
+ * @param time Properly formatted time string
+ * @returns How many minutes after midnight the time parameter is (ex. 01:30 is 90 minutes after midnight)
+ */
 function getMinutesFromMidnight(time: string) {
     // time is necessarily in HH:MM format
     const separatedTime = time.split(":");

--- a/themeToggler.ts
+++ b/themeToggler.ts
@@ -8,17 +8,30 @@ import { Settings } from "@api/Settings";
 import { Logger } from "@utils/Logger";
 import { findByCodeLazy } from "@webpack";
 
-import { DiscordTheme } from "./types";
+import { CustomTheme, DiscordTheme } from "./types";
 
 const logger = new Logger("AutoThemeSwitcher", "#BBBBBB");
 
+/**
+ * Check if a theme is the Nitro custom theme or not
+ * @param input Any object that needs to be checked for the type customTheme
+ * @returns A boolean; true if it is a custom Nitro theme, false if otherwise
+ */
+const isOfTypeCustomTheme = (input: any): input is CustomTheme => input.theme !== undefined && input.customUserThemeSettings !== undefined;
+
+/**
+ * Formatting of the request to send to the settings update payload to change the theme
+ */
 interface SaveThemeRequest {
     theme: string;
     backgroundGradientPresetId?: number;
 }
 
-const saveClientTheme: (theme: SaveThemeRequest) => void
-    = findByCodeLazy('type:"UNSYNCED_USER_SETTINGS_UPDATE', '"system"===');
+/**
+ * Method to update the theme using the settings update payload.
+ * @param theme A Discord theme request
+ */
+const saveClientTheme: (theme: Object) => void = findByCodeLazy('type:"UNSYNCED_USER_SETTINGS_UPDATE', '"system"===');
 
 /**
  * @param theme A Discord theme
@@ -30,19 +43,31 @@ export function themeToString(theme: DiscordTheme) {
 
 /**
  * Changes the Discord theme to the specified one.
- * @param theme The identifier of the Discord theme to set (as returned by {@link themeToString})
+ * @param theme The identifier of the Discord theme to set, as returned by {@link themeToString}, or passed directly as a properly formatted theme (for the custom Nitro theme)
  */
-export function changeDiscordTheme(theme: string) {
-    const themeComponents = theme.split("-");
-    const saveThemeRequest: SaveThemeRequest = { theme: themeComponents[0] };
+export function changeDiscordTheme(theme: string | CustomTheme) {
 
-    const themeId = parseInt(themeComponents[1]);
-    if (!isNaN(themeId)) {
-        saveThemeRequest.backgroundGradientPresetId = themeId;
+    // Operate differently depending on if this is a pre-set theme (Nitro or not) or if this is a custom Nitro theme
+    if (typeof theme === "string") {
+        const themeComponents = theme.split("-");
+        const saveThemeRequest: SaveThemeRequest = { theme: themeComponents[0] };
+
+        const themeId = parseInt(themeComponents[1]);
+        if (!isNaN(themeId)) {
+            saveThemeRequest.backgroundGradientPresetId = themeId;
+        }
+        saveClientTheme(saveThemeRequest);
+        logger.info("Discord Theme changed to", saveThemeRequest);
     }
 
-    saveClientTheme(saveThemeRequest);
-    logger.info("Discord Theme changed to", saveThemeRequest);
+    else if (isOfTypeCustomTheme(theme)) {
+        saveClientTheme(theme);
+        logger.info("Discord Theme changed to", theme);
+    }
+    //If anything else, it is an error
+    else {
+        throw new Error ("Invalid theme request.");
+    }
 }
 
 /**

--- a/timeComponent.tsx
+++ b/timeComponent.tsx
@@ -1,0 +1,68 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Settings } from "@api/Settings";
+import { resolveError, SettingsSection } from "@components/settings/tabs/plugins/components/Common";
+import { TextSetting } from "@components/settings/tabs/plugins/components/TextSetting";
+import { IPluginOptionComponentProps, OptionType } from "@utils/types";
+import { React } from "@webpack/common";
+
+/**
+ * Creation of a JSX text component that hides based on the ChangeBasedOnSystemAppearance setting
+ * It allows the removal of the time setting if the user chooses to use system appearance rather than time for the theme change
+ * Loosely based on themeLinksComponent.tsx
+ * @param setValue Properties of the specific setting; only the setValue function is necessary, for changing the value if valid
+ * @param id The id of the setting the text input represents
+ * @param placeholder A default value for when the text input is not set by the user
+ * @param description A description of the text input
+ * @returns JSX representing the input for time
+ */
+export function timeComponent({ setValue }: IPluginOptionComponentProps, id: string, placeholder: string, description: string) {
+    const pluginSettings = Settings.plugins.AutoThemeSwitcher;
+    // TextSetting handles state, not needed here
+    const [, setState] = React.useState(pluginSettings?.[id] ?? null);
+    const [error, setError] = React.useState<string | null>(null);
+
+    // Internal function to check if the time string is valid
+    function regexValidateCheck(newValue: string) {
+        const timeRegex = /^([0-1][0-9]|2[0-3]):([0-5][0-9])$/;
+        return newValue.match(timeRegex) !== null;
+    }
+
+    // Internal function to handle changes in the value
+    function handleChange(newValue: string) {
+        // Check validity on our own terms
+        const isValid = regexValidateCheck(newValue);
+
+        setState(newValue);
+        setError(resolveError(isValid));
+
+        if (isValid === true) {
+            setValue(newValue);
+        }
+    }
+
+    // Hide the setting if we're using the system theme rather than time of day
+    // This was the whole purpose of making a component setting!
+    if (Settings.plugins["AutoThemeSwitcher"].ChangeBasedOnSystemAppearance)
+        return null;
+
+    return (
+        <SettingsSection error={error} name={""} description={""}>
+        <TextSetting
+            option={{
+                type: OptionType.STRING,
+                // Determine if we autofill the field with the default, or with what the user entered
+                default: (pluginSettings?.[id] != null || pluginSettings?.[id]) ? pluginSettings?.[id] : placeholder,
+                description: description
+            }}
+            onChange={handleChange}
+            pluginSettings={pluginSettings}
+            id={id}
+        />
+        </SettingsSection>
+    );
+}

--- a/types.ts
+++ b/types.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+import { FluxStore } from "@vencord/discord-types/src/stores/FluxStore";
+
 /**
  * The 2 themes that this plugin can toggle between: Light and Dark.
  */
@@ -30,3 +32,24 @@ export interface NitroThemeColor {
     token: string;
     stop: number;
 }
+
+/**
+ * Representation of the custom Nitro Discord theme.
+ * As of coding this, there is only one customization per account, so didn't bother with an interface.
+ */
+export type CustomTheme = {
+    theme: string;
+    customUserThemeSettings: {
+        colors: Array<string>;
+        base_mix: 0;
+        gradient_angle: 0;
+        base_theme: string;
+    };
+};
+
+/**
+ * Custom Nitro theme store.
+ */
+export type CtStore = FluxStore & {
+    getSavedCustomTheme: Function
+};


### PR DESCRIPTION
Hello there,

I revamped your auto theme switcher for Vencord. I combined both your plugin and [adorabilis' fork.](https://github.com/adorabilis/Vencord-SystemThemeSwitcher) The features added are:

- A toggle switch which decides whether theme switching should be based on the time of day, or by system appearance
- Added support for the custom Nitro theme

I also made minor changes, like removing the depreciated Forms component, made the time input a custom component (so it can be hidden if the user chooses system appearance), and better documentation.

Let me know what you think, maybe this can be uploaded to Vencord's store if possible. I credited all 3 of us.